### PR TITLE
Fix for fisherfriends rep to max level

### DIFF
--- a/RepHelper.lua
+++ b/RepHelper.lua
@@ -3701,7 +3701,7 @@ function RPH:SortByStanding(i,factionIndex,factionRow,factionBar,factionBarPrevi
 
 		local toBFF = 0
 		if (isCappedFriendship ~= true and isFriend) then
-			toBFF = RPH_GetFriendFactionRemaining(factionid, factionStandingtext, barMax, barValue)
+			toBFF = RPH_GetFriendFactionRemaining(factionID, factionStandingtext, barMax, barValue)
 		end
 
 		factionRow.index = OBS_fi_i;
@@ -3898,7 +3898,7 @@ function RPH:OriginalRepOrder(i,factionIndex,factionRow,factionBar,factionBarPre
 
 	local toBFF = 0
 	if (isCappedFriendship ~= true and isFriend) then
-		toBFF = RPH_GetFriendFactionRemaining(factionid, factionStandingtext, barMax, barValue)
+		toBFF = RPH_GetFriendFactionRemaining(factionID, factionStandingtext, barMax, barValue)
 	end
 
 

--- a/RepHelper.lua
+++ b/RepHelper.lua
@@ -3531,40 +3531,9 @@ function RPH_OptionsDefault()
 end
 
 function RPH_GetFriendFactionRemaining(factionID, factionStandingtext, barMax, barValue)
-	local RPH_ToBFF = {}
-	RPH_ToBFF[0] = {}	                    --> Friendship levels:
-	RPH_ToBFF[0]["Stranger"] = 33600;	    --> 1 - Stranger: 0-8400
-	RPH_ToBFF[0]["Acquaintance"] = 25200;	--> 2 - Acquaintance: 8400-16800
-	RPH_ToBFF[0]["Buddy"] = 16800;	        --> 3 - Buddy: 16800-25200
-	RPH_ToBFF[0]["Friend"] = 8400;	    --> 4 - Friend: 25200-33600
-	RPH_ToBFF[0]["Good Friend"] = 0;	--> 5 - Good Friend: 33600-42000
-	RPH_ToBFF[0]["Best Friend"] = 0;	--> 6 - Best Friend: 42000-42999
-	-- Fisher[0][riend Corbyn
-	RPH_ToBFF[2100] = {}
-	RPH_ToBFF[2100]["Stranger"] = 33600;	
-	RPH_ToBFF[2100]["Curiosity"] = 25200 --> Acquaintance
-	RPH_ToBFF[2100]["Non-Threat"] = 16800 --> Buddy
-	RPH_ToBFF[2100]["Friend"] = 8400;	 
-	RPH_ToBFF[2100]["Helpful Friend"] = 0 --> Good Friend
-	RPH_ToBFF[2100]["Best Friend"] = 0;
-	-- Nat Pagle
-	RPH_ToBFF[1358] = {}
-	RPH_ToBFF[1358]["Stranger"] = 33600;
-	RPH_ToBFF[1358]["Pal"] = 25200 --> Acquaintance
-	RPH_ToBFF[1358]["Buddy"] = 16800;
-	RPH_ToBFF[1358]["Friend"] = 8400;
-	RPH_ToBFF[1358]["Good Friend"] = 0;
-	RPH_ToBFF[1358]["Best Friend"] = 0;
+	local _, friendRep, friendMaxRep, _, _, _, _, _, _ = GetFriendshipReputation(factionID);
 
-	if RPH_ToBFF[factionID] ~= nil then
-		return RPH_ToBFF[factionID][factionStandingtext] + barMax - barValue
-	else
-		if RPH_ToBFF[0][factionStandingtext] ~=nil then
-			return RPH_ToBFF[0][factionStandingtext] + barMax - barValue
-		else
-			return 0
-		end
-	end
+	return friendMaxRep - friendRep;
 end
 
 function RPH_GetFriendFactionStandingLabel(factionID, nextFriendThreshold)


### PR DESCRIPTION
I found two issues, firstly, the factionID sent in had the wrong casing, so it was always null.
Second, instead of adding to the table (there would have been a lot), I decided to try to fix it with WoW's own API calls.

When using the API calls it also fixes Chromie in addition to the fisher friends.

The only drawback I saw of using the API is that for the wingmen, you will also get max reputation 42k, even if it's just 20k or so.

However, the current code had it wrong also, so maybe one should add additional checks for if it's one of the wingmen and override the maxPalRep for them.